### PR TITLE
Switch SafeAreaView to react-native-safe-area-context

### DIFF
--- a/main/app/help-and-support.tsx
+++ b/main/app/help-and-support.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Linking, ScrollView, Alert } from "react-native";
+import { Text, View, StyleSheet, TouchableOpacity, Linking, ScrollView, Alert } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 

--- a/main/app/index.tsx
+++ b/main/app/index.tsx
@@ -1,4 +1,5 @@
-import { Text, View, StyleSheet, TouchableOpacity, SafeAreaView, Image } from "react-native";
+import { Text, View, StyleSheet, TouchableOpacity, Image } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import GoogleAuth from "../src/components/auth/google-auth";
 

--- a/main/app/login.tsx
+++ b/main/app/login.tsx
@@ -1,4 +1,5 @@
-import { Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Alert, Image } from "react-native";
+import { Text, View, StyleSheet, TouchableOpacity, Alert, Image } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { 

--- a/main/app/welcome.tsx
+++ b/main/app/welcome.tsx
@@ -1,4 +1,5 @@
-import { Text, View, StyleSheet, SafeAreaView, TouchableOpacity, TextInput, Image, Alert, ActivityIndicator } from "react-native";
+import { Text, View, StyleSheet, TouchableOpacity, TextInput, Image, Alert, ActivityIndicator } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useEffect, useState } from "react";


### PR DESCRIPTION
Replaced SafeAreaView imports from 'react-native' with 'react-native-safe-area-context' across multiple screens for improved compatibility. Also updated scan.tsx to handle missing expo-camera module gracefully, providing a manual entry fallback if the camera is unavailable.